### PR TITLE
Configure to look into env vars only

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,7 @@
-org.gradle.java.installations.paths=/path/to/your/jdk
+# Disable toolchain auto-detection, so that it doesn't look in places like SDKMan!
+org.gradle.java.installations.auto-detect=false
+# Disable auto-downloading of JDK installations
+org.gradle.java.installations.auto-download=false
+# Provide a list of environment variables to look for
+org.gradle.java.installations.fromEnv=JAVA20_HOME
+


### PR DESCRIPTION
So with this setup:

- Gradle will look for JDKs by looking into the `JAVA20_HOME` environment variable only
- you can set the path to the JDK via command line

For a single invocation, you can run, for example:

`JAVA20_HOME=~/.sdkman/candidates/java/20.ea.24-open ./gradlew test`

Or you can export the variable so that it survives multiple invocations:

```bash
export JAVA20_HOME=~/.sdkman/candidates/java/20.ea.24-open
./gradlew test
```

and switching between variants of JDK 20 will only be a matter of overriding the environment variable.

